### PR TITLE
Fix paths of binaries and models as they point to an unexisting directory

### DIFF
--- a/predictText.py
+++ b/predictText.py
@@ -7,8 +7,8 @@ import os
 os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"   # see issue #152
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
-binaryPath= 'data/binaries/'    #Place where the serialized training data is
-modelPath= 'data/models/'       #Place to store the models
+binaryPath= 'binaries/'    #Place where the serialized training data is
+modelPath= 'models/'       #Place to store the models
 
 #Load Model
 textBranch = load_model(modelPath +'/textBranchNorm.h5')


### PR DESCRIPTION
`predicText.py` cannot be run as it is explained in the documentation. The error is because the paths of binaries and models point to a data directory that does not exist in the root directory. Either the documentation should ask users to first create a directory called `data` and then extract models and binaries there or the paths declared in `predicText.py` should not contain prepended the data directory. This request fixes the issue following the latter approach.