### PR TITLE
Listen by default on all IPs, not just localhost

### DIFF
--- a/webservice.py
+++ b/webservice.py
@@ -119,4 +119,4 @@ def predictText():
         return Response(json.dumps(x, indent=4), mimetype='application/json')
 
 if __name__ == '__main__':
-   app.run(host="127.0.0.1", port=8080)
+   app.run(host="0.0.0.0", port=8080)


### PR DESCRIPTION
This is particularly relevant when running within the ELG Kubernetes infrastructure - the liveness checker needs to be able to connect to the running container via the pod IP address in order to verify that the container is still alive, so if the app is only listening on 127.0.0.1 it will fail the liveness checks and will be repeatedly restarted un-necessarily.